### PR TITLE
Fix file match for containerfiles in regex manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,7 +13,10 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^Dockerfile"],
+      "fileMatch": [
+        "(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$",
+        "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$"
+      ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sENV .*?_VERSION=\"(?<currentValue>.*)\"\\s"
       ],


### PR DESCRIPTION
This fixes the failing CI https://ci.woodpecker-ci.org/repos/3780/pipeline/13957/11 by correctly detecting and updating alpine package updates. 

Use the defaults from the Dockerfile manager https://docs.renovatebot.com/modules/manager/dockerfile/#default-config