### PR TITLE
Fix custom manager for gitpod

### DIFF
--- a/default.json
+++ b/default.json
@@ -27,7 +27,7 @@
       "customType": "regex",
       "fileMatch": ["^Makefile$", "^.gitpod.yml$"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\n.*?_VERSION (:|\\?)= (?<currentValue>.*)\\s"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s+.*?_VERSION\\s*:*\\??=\\s*(?<currentValue>.+)\\s"
       ]
     }
   ],


### PR DESCRIPTION
Works now properly with both cases (hopefully).

![grafik](https://github.com/user-attachments/assets/79b8489b-b25c-4dc8-b2aa-2f125a688d2f)
