### PR TITLE
Disable automerge for ansible deps

### DIFF
--- a/default.json
+++ b/default.json
@@ -60,13 +60,13 @@
       "addLabels": ["build"]
     },
     {
-      "matchManagers": ["custom.regex"],
-      "matchFileNames": ["/^(group_vars|host_vars)/.+?$/"],
-      "automerge": false
-    },
-    {
-      "matchManagers": ["ansible"],
-      "automerge": false
+      "matchManagers": ["custom.regex", "ansible"],
+      "matchFileNames": ["/^(roles/group_vars|host_vars)/.+?$/"],
+      "automerge": false,
+      "prBodyNotes": [
+        ":warning: **Manual Steps required**",
+        "Remember to always deploy the updated dependencies after merging the PR by running `./ansible.sh`."
+      ]
     }
   ],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],


### PR DESCRIPTION
As changes to Ansible managed deps need a deployment, we should never automerge them. Also add a warning to the PRs to remember the manual steps.